### PR TITLE
Clean the node_modules directory when we do "mvn clean".

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,17 @@
 
     <build>
         <plugins>
+	    <plugin>
+	        <artifactId>maven-clean-plugin</artifactId>
+		<version>2.5</version>
+		<configuration>
+		    <filesets>
+		        <fileset>
+			    <directory>${basedir}/node_modules</directory>
+			</fileset>
+		    </filesets>
+		</configuration>
+	    </plugin>
             <plugin>
                 <groupId>com.github.github</groupId>
                 <artifactId>site-maven-plugin</artifactId>


### PR DESCRIPTION
Without this, "mvn clean" still leaves build/install artifacts
in the source tree.
